### PR TITLE
Issue #8 Data deserialization problem

### DIFF
--- a/src/main/java/org/omg/sysml/JSON.java
+++ b/src/main/java/org/omg/sysml/JSON.java
@@ -58,7 +58,7 @@ public class JSON {
                         Map<String, Class> classByDiscriminatorValue = new HashMap<String, Class>();
                         classByDiscriminatorValue.put("Constraint", Constraint.class);
                         return getClassByDiscriminator(classByDiscriminatorValue,
-                                getDiscriminatorValue(readElement, "@type"));
+                                getDiscriminatorValue(readElement, "@type"), Constraint.class);
                     }
           })
                 .registerTypeSelector(Data.class, new TypeSelector() {
@@ -67,7 +67,7 @@ public class JSON {
                         Map<String, Class> classByDiscriminatorValue = new HashMap<String, Class>();
                         classByDiscriminatorValue.put("Data", Data.class);
                         return getClassByDiscriminator(classByDiscriminatorValue,
-                                getDiscriminatorValue(readElement, "@type"));
+                                getDiscriminatorValue(readElement, "@type"), Data.class);
                     }
           })
         ;
@@ -90,10 +90,13 @@ public class JSON {
      * @param discriminatorValue The value of the OpenAPI discriminator in the input data.
      * @return The Java class that implements the OpenAPI schema
      */
-    private static Class getClassByDiscriminator(Map classByDiscriminatorValue, String discriminatorValue) {
+    private static Class getClassByDiscriminator(Map classByDiscriminatorValue, String discriminatorValue, Class defaultClass) {
         Class clazz = (Class) classByDiscriminatorValue.get(discriminatorValue);
         if (null == clazz) {
-            throw new IllegalArgumentException("cannot determine model class of name: <" + discriminatorValue + ">");
+            if(null == defaultClass) {
+                throw new IllegalArgumentException("cannot determine model class of name: <" + discriminatorValue + ">");
+            }
+            return defaultClass;
         }
         return clazz;
     }

--- a/src/test/java/org/omg/sysml/JSONTest.java
+++ b/src/test/java/org/omg/sysml/JSONTest.java
@@ -1,0 +1,41 @@
+package org.omg.sysml;
+
+import org.junit.Test;
+import org.omg.sysml.model.Commit;
+
+import java.lang.reflect.Type;
+
+import static org.junit.Assert.*;
+
+public class JSONTest {
+    private final JSON json = new JSON();
+
+    /**
+     * Tests JSON deserialization with a Commit provided in a string in JSON format.
+     */
+    @Test
+    public void testJsonDeserialization() {
+        String elementId = "13ca289c-b7fe-4f41-a639-1e8f9b3199d5";
+        String jsonString =
+                "{" +
+                    "\"@id\":\"36391e9a-8ab2-4a1a-bd6f-93edd0361c5f\"," +
+                    "\"@type\":\"Commit\"," +
+                    "\"change\":[" +
+                        "{" +
+                            "\"identity\":{" +
+                                "\"@id\":\"" + elementId + "\"," +
+                                "\"@type\":\"DataIdentity\"" +
+                            "}," +
+                            "\"payload\":{" +
+                                "\"@type\":\"ActionDefinition\"," +
+                                "\"@id\":\"" + elementId + "\"," +
+                                "\"elementId\":\"" + elementId + "\"" +
+                            "}" +
+                        "}" +
+                    "]" +
+                "}";
+        Type type = Commit.class;
+        Commit commit = json.deserialize(jsonString, type);
+        assertEquals(elementId, commit.getChange().get(0).getPayload().get("elementId"));
+    }
+}


### PR DESCRIPTION
Fixes #8.

Makes sure that deserialization always succeeds with a default all-encompassing type, as a hotfix. Leaves open the future possibility of making the `classByDiscriminatorValue` hashmap extensible by more specific classes.